### PR TITLE
fix Rotterdam page header links

### DIFF
--- a/pages/rotterdam.html
+++ b/pages/rotterdam.html
@@ -27,9 +27,9 @@
                     <img src="../images/logo_en.svg" alt="Logo the Netherlands"></a>
             </div>
             <ul class="header_navigation">
-                <li><a href="/pages/amsterdam.html">Amsterdam</a></li>
-                <li><a href="/pages/the_hague.html">The Hague</a></li>
-                <li><a href="/pages/utrecht.html">Utrecht</a></li>
+                <li><a href="./amsterdam.html">Amsterdam</a></li>
+                <li><a href="./the_hague.html">The Hague</a></li>
+                <li><a href="./utrecht.html">Utrecht</a></li>
             </ul>
             
             <div class="header_button">


### PR DESCRIPTION
Links have been converted to a universal form (using ./ or ../).